### PR TITLE
Some improvements to the `simulator run` step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,9 @@ gnbsim-docker-stop:
 
 #### c. Provision gnbsim ####
 gnbsim-simulator-run:
-	ansible-playbook -i $(HOSTS_INI_FILE) $(GNBSIM_ROOT_DIR)/simulator.yml --tags start \
-		--extra-vars "ROOT_DIR=$(ROOT_DIR)" --extra-vars $(EXTRA_VARS)
+	ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i $(HOSTS_INI_FILE) \
+		$(GNBSIM_ROOT_DIR)/simulator.yml --tags start --extra-vars \
+		"ROOT_DIR=$(ROOT_DIR)" --extra-vars $(EXTRA_VARS)
 
 
 # run gnbsim-docker-install before running setup

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -69,10 +69,3 @@
 - debug:
     var: gNbsimPod.stdout_lines
   when: inventory_hostname in groups['gnbsim_nodes']
-
-- name: force stop gnbsim
-  shell: |
-    pkill -9 -f /gnbsim/bin/gnbsim
-  become: true
-  when: inventory_hostname in groups['gnbsim_nodes']
-  ignore_errors: yes

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -66,6 +66,12 @@
   register: gNbsimPod
   when: inventory_hostname in groups['gnbsim_nodes']
 
+- name: Check if simulation failed
+  set_fact:
+    status_fail: "{{ 'Status: FAIL' in gNbsimPod.stdout }}"
+
 - debug:
     msg: "{{ gNbsimPod.stdout_lines | regex_replace(' category=Summary component=GNBSIM','') }}"
-  when: inventory_hostname in groups['gnbsim_nodes'] and gNbsimPod.stdout_lines is defined
+  when: inventory_hostname in groups['gnbsim_nodes']
+  failed_when: status_fail
+  ignore_errors: yes

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -67,5 +67,5 @@
   when: inventory_hostname in groups['gnbsim_nodes']
 
 - debug:
-    var: gNbsimPod.stdout_lines
-  when: inventory_hostname in groups['gnbsim_nodes']
+    msg: "{{ gNbsimPod.stdout_lines | regex_replace(' category=Summary component=GNBSIM','') }}"
+  when: inventory_hostname in groups['gnbsim_nodes'] and gNbsimPod.stdout_lines is defined


### PR DESCRIPTION
This PR makes several improvements to the `simulation run` step:
# Summary:
1. Add `ANSIBLE_STDOUT_CALLBACK=yaml` to make user-friendly the output of the simulator (simulation result)
2. Remove the last step of the `aether-onramp/deps/gnbsim/roles/simulator/tasks/start.yml` because it will always fail. The gnbsim process will finish/end by itself as soon as the simulation completes so, the last step will always result in error because the process no longer exists
3. An additional improvement is about what output to print such that the user can easily see whether the simulation successfully completed or not and this is achieved by removing irrelevant information/output (i.e., remove `category=Summary component=GNBSIM`
4. Print output in green (as default in Ansible) when the simulation successfully completes and print the output in red when the simulation fails

# Details
## 1. Add `ANSIBLE_STDOUT_CALLBACK=yaml` to make user-friendly the output of the simulator (simulation result).

Before:
```
TASK [simulator : debug] ***********************************************************************************************
ok: [node1] => {
    "gNbsimPod.stdout_lines": [
        "time=\"2024-09-13T17:56:28Z\" level=info msg=\"Profile Name: profile1 , Profile Type: register\" category=Summary component=GNBSIM",
        "time=\"2024-09-13T17:56:28Z\" level=info msg=\"Ue's Passed: 5 , Ue's Failed: 0\" category=Summary component=GNBSIM",
        "time=\"2024-09-13T17:56:28Z\" level=info msg=\"Profile Status: PASS\" category=Summary component=GNBSIM"
    ]
}
```

Now:
```
TASK [simulator : debug] ***********************************************************************************************
ok: [node1] =>
  gNbsimPod.stdout_lines:
  - 'time="2024-09-13T17:42:23Z" level=info msg="Profile Name: profile1 , Profile Type: register" category=Summary component=GNBSIM'
  - 'time="2024-09-13T17:42:23Z" level=info msg="Ue''s Passed: 5 , Ue''s Failed: 0" category=Summary component=GNBSIM'
  - 'time="2024-09-13T17:42:23Z" level=info msg="Profile Status: PASS" category=Summary component=GNBSIM'
```

## 2. Remove the last step of the `roles/simulator/tasks/start.yml` because it will always fail. The gnbsim process will finish/end by itself as soon as the simulation completes so, the last step will always result in error because the process no longer exists

Before:
```
TASK [simulator : force stop gnbsim] ***********************************************************************************
fatal: [node1]: FAILED! => {"changed": true, "cmd": "pkill -9 -f /gnbsim/bin/gnbsim\n", "delta": "0:00:00.044992", "end": "2024-09-13 10:56:40.856013", "msg": "non-zero return code", "rc": -9, "start": "2024-09-13 10:56:40.811021", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring
```
Now:
```
There is no error :-)
```

## 3. An additional improvement is about what output to print such that the user can easily see whether the simulation successfully completed or not and this is achieved by removing irrelevant information/output (i.e., remove `category=Summary component=GNBSIM`.

Before (after item 1. above is accepted/merged):
```
TASK [simulator : debug] ***********************************************************************************************
ok: [node1] =>
  gNbsimPod.stdout_lines:
  - 'time="2024-09-13T19:07:53Z" level=info msg="Profile Name: profile1 , Profile Type: register" category=Summary component=GNBSIM'
  - 'time="2024-09-13T19:07:53Z" level=info msg="Ue''s Passed: 5 , Ue''s Failed: 0" category=Summary component=GNBSIM'
  - 'time="2024-09-13T19:07:53Z" level=info msg="Profile Status: PASS" category=Summary component=GNBSIM'
```
Now:
```
TASK [simulator : debug] ***********************************************************************************************
ok: [node1] =>
  msg:
  - 'time="2024-09-13T19:01:10Z" level=info msg="Profile Name: profile1 , Profile Type: register"'
  - 'time="2024-09-13T19:01:10Z" level=info msg="Ue''s Passed: 5 , Ue''s Failed: 0"'
  - 'time="2024-09-13T19:01:10Z" level=info msg="Profile Status: PASS"'
```

## 4. Print output in green (as default in Ansible) when the simulation successfully completes and print the output in red when the simulation fails
When simulation successfully completes (green)
![image](https://github.com/user-attachments/assets/2a2ac9e7-012f-464e-b0ad-559fd1036ddb)

When simulation fails (red)
![image](https://github.com/user-attachments/assets/6d447f58-1001-469c-8438-aa8d64a562f4)


