### PR TITLE
Make a couple improvements about results output and add missing profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ gnbsim-docker-stop:
 
 #### c. Provision gnbsim ####
 gnbsim-simulator-run:
-	ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i $(HOSTS_INI_FILE) \
+	ansible-playbook -i $(HOSTS_INI_FILE) \
 		$(GNBSIM_ROOT_DIR)/simulator.yml --tags start --extra-vars \
 		"ROOT_DIR=$(ROOT_DIR)" --extra-vars $(EXTRA_VARS)
 

--- a/config/gnbsim-all.yaml
+++ b/config/gnbsim-all.yaml
@@ -205,6 +205,21 @@ configuration:
     key: "5122250214c33e723a5dd523fc145fc0"
     sequenceNumber: "16f3b3f70fc2"
 
+  - profileType: nwreqpdusessrelease # Network Requested PDU Session Release
+    profileName: profile8
+    enable: false
+    gnbName: gnb1
+    execInParallel: false
+    startImsi: 208930100007570
+    ueCount: 1
+    plmnId:
+      mcc: 208
+      mnc: 93
+    defaultAs: "192.168.250.1"
+    opc: "981d464c7c52eb6e5036234984ad0bcf"
+    key: "5122250214c33e723a5dd523fc145fc0"
+    sequenceNumber: "16f3b3f70fc2"
+
 # Set logging level
 logger:
   logLevel: info		# trace, debug, info, warn, error, fatal, panic

--- a/config/gnbsim-default.yaml
+++ b/config/gnbsim-default.yaml
@@ -205,6 +205,21 @@ configuration:
     key: "5122250214c33e723a5dd523fc145fc0"
     sequenceNumber: "16f3b3f70fc2"
 
+  - profileType: nwreqpdusessrelease # Network Requested PDU Session Release
+    profileName: profile8
+    enable: false
+    gnbName: gnb1
+    execInParallel: false
+    startImsi: 208930100007497
+    ueCount: 1
+    plmnId:
+      mcc: 208
+      mnc: 93
+    defaultAs: "192.168.250.1"
+    opc: "981d464c7c52eb6e5036234984ad0bcf"
+    key: "5122250214c33e723a5dd523fc145fc0"
+    sequenceNumber: "16f3b3f70fc2"
+
 # Set logging level
 logger:
   logLevel: info		# trace, debug, info, warn, error, fatal, panic

--- a/config/gnbsim-upf-1.yaml
+++ b/config/gnbsim-upf-1.yaml
@@ -205,6 +205,21 @@ configuration:
     key: "5122250214c33e723a5dd523fc145fc0"
     sequenceNumber: "16f3b3f70fc2"
 
+  - profileType: nwreqpdusessrelease # Network Requested PDU Session Release
+    profileName: profile8
+    enable: false
+    gnbName: gnb1
+    execInParallel: false
+    startImsi: 208930100007497
+    ueCount: 1
+    plmnId:
+      mcc: 208
+      mnc: 93
+    defaultAs: "192.168.250.1"
+    opc: "981d464c7c52eb6e5036234984ad0bcf"
+    key: "5122250214c33e723a5dd523fc145fc0"
+    sequenceNumber: "16f3b3f70fc2"
+
 # Set logging level
 logger:
   logLevel: info		# trace, debug, info, warn, error, fatal, panic

--- a/config/gnbsim-upf-2.yaml
+++ b/config/gnbsim-upf-2.yaml
@@ -202,6 +202,21 @@ configuration:
     key: "5122250214c33e723a5dd523fc145fc0"
     sequenceNumber: "16f3b3f70fc2"
 
+  - profileType: nwreqpdusessrelease # Network Requested PDU Session Release
+    profileName: profile8
+    enable: false
+    gnbName: gnb1
+    execInParallel: false
+    startImsi: 208930100007497
+    ueCount: 1
+    plmnId:
+      mcc: 208
+      mnc: 93
+    defaultAs: "192.168.250.1"
+    opc: "981d464c7c52eb6e5036234984ad0bcf"
+    key: "5122250214c33e723a5dd523fc145fc0"
+    sequenceNumber: "16f3b3f70fc2"
+
 # Set logging level
 logger:
   logLevel: info		# trace, debug, info, warn, error, fatal, panic

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -71,7 +71,7 @@
     status_fail: "{{ 'Status: FAIL' in gNbsimPod.stdout }}"
 
 - debug:
-    msg: "{{ gNbsimPod.stdout_lines | regex_replace(' category=Summary component=GNBSIM','') }}"
+    msg: "{{ gNbsimPod.stdout_lines | map('regex_replace', '^([^\t]*\t){3}([^\t]*)\t.*$', '\\2') | list }}"
   when: inventory_hostname in groups['gnbsim_nodes']
   failed_when: status_fail
   ignore_errors: yes


### PR DESCRIPTION
This PR does the following:

1. A couple improvements/changes aligned with the latest `gnbsim` image that uses `zap` logger instead of `logrus`
2. Add missing profile (profile8) to the configuration files that are missing it (Profile is disabled by default) and the purpose of adding it is for the users to be aware of the existence of this profile
3. Changes were tested using the `quickstart` blueprint

**Note:** There is a PR for the `aether-onramp` that needs to be open (after this PR is merged) to use latest Helm Charts and latest `gnbsim` image

Now, output looks like this:
![image](https://github.com/user-attachments/assets/e15455a1-d12a-425f-afbd-71fd7b32af6a)
