### PR TITLE
Fix: Install Python Docker Module in a Virtual Environment  

### DIFF
--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -77,9 +77,16 @@
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 
-- name: install docker module for Python
+- name: Create a virtual environment for Python
+  ansible.builtin.command:
+    cmd: python3 -m venv /opt/dockerenv
+  when: inventory_hostname in groups['gnbsim_nodes']
+  become: true
+
+- name: Install docker module for Python in virtual environment
   pip:
     name: docker
+    virtualenv: /opt/dockerenv
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 


### PR DESCRIPTION
**Title**: Fix: Install Python Docker Module in a Virtual Environment  

**Description**:  
This PR addresses the issue of failing to install the Python `docker` module in an externally managed environment. The issue occurred because direct installation with `pip` was restricted. To resolve this, a virtual environment is created, and the module is installed within it.  

**Changes Made**:  
1. Added a task to create a Python virtual environment (`/opt/dockerenv`).
2. Modified the `install docker module for Python` task to use the created virtual environment.
3. Ensured all other related tasks remain functional without additional changes.  

### Fixes #17 
**Before Fix (Error Log)**:  
![Screenshot from 2025-01-28 03-46-20](https://github.com/user-attachments/assets/61795f34-38c4-4fdb-be44-c08ea5f0fc53)

The error highlighted the `externally-managed-environment` restriction, preventing direct `pip` installations.  

**After Fix**:  
- Successfully installs the Python `docker` module using a virtual environment.  
- Playbook execution completes without errors.  

**Testing**:  
- Verified on Ubuntu with Python 3.12.  
- Confirmed the `hello-world` Docker container is created and run successfully as part of the playbook execution.  

**Branch**: `fix/python-docker-venv-install`  
 

**Screenshots**:  
![Screenshot from 2025-01-28 03-53-20](https://github.com/user-attachments/assets/ca63ba8a-7593-4d9c-a63f-0879caa66989)

@llpeterson plz review my PR  

