### PR TITLE
bugfix: gnbsim macvlan.conf clobbers 5gc macvlan.conf

### DIFF
--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -74,10 +74,10 @@
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 
-- name: "copy macvlan.conf to {{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan.conf"
+- name: "copy macvlan.conf to {{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan-gnbsim.conf"
   template:
     src: roles/router/templates/macvlan.conf
-    dest: "{{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan.conf"
+    dest: "{{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan-gnbsim.conf"
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 

--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -76,6 +76,7 @@
     state: absent
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
+  ignore_errors: yes
 
 - name: delete {{ systemd_network_dir }}/20-gnbsim-access.network
   file:

--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -70,10 +70,15 @@
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 
-- name: delete {{ systemd_network_dir }}/{{ result.stdout }}.d
+- name: delete {{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan-gnbsim.conf
   file:
-    path: "{{ systemd_network_dir }}/{{ result.stdout }}.d"
+    path: "{{ systemd_network_dir }}/{{ result.stdout }}.d/macvlan-gnbsim.conf"
     state: absent
+  when: inventory_hostname in groups['gnbsim_nodes']
+  become: true
+
+- name: delete {{ systemd_network_dir }}/{{ result.stdout }}.d if empty
+  shell: rmdir {{ systemd_network_dir }}/{{ result.stdout }}.d
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
   ignore_errors: yes


### PR DESCRIPTION
When installing both `5gc` and `gnbsim` on a single machine, they both place a `macvlan.conf` file in the same directory, causing one to overwrite the other, and preventing the macvlan bridges from coming up properly after a server restart.

The following steps should reproduce the bug:
```
make k8s-install
make 5gc-install
IFACE=$(grep -r "data_iface" vars/main.yml | head -n 1 | sed "s/.*: //g")
CONF=$(basename $(find /*/systemd/network -maxdepth 1 -not -type d -name "*$IFACE.network" -print))
tail -v /etc/systemd/network/$CONF.d/*.conf
```
At this point, you should see a single macvlan config file specifying the `core` and `access` bridges. Now, install gnbsim:
```
make gnbsim-install
tail -v /etc/systemd/network/$CONF.d/*.conf
```
You should now see a single macvlan config file containing only the `gnbaccess` bridge (it has overwritten the previous file). At this point, if you restart the machine and do the following, only the `gnbaccess` bridge will be up (not `core` or `access`):
```
sudo ip addr show gnbaccess
sudo ip addr show access
sudo ip addr show core
```
This bug fix simply renames the `gnbsim` macvlan config file from `macvlan.conf` to `macvlan-gnbsim.conf`, to avoid colliding with the file installed by `5gc`.