### PR TITLE
Properly enable printing logs to terminal as well as file

### DIFF
--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -40,11 +40,16 @@
 - name: start gnbsim
   community.docker.docker_container_exec:
     container: "{{ gnbsim.docker.container.prefix }}-{{ (item.0|int)+1 }}"
-    command: /bin/bash -c "rm -rf *.log; rm -f *.config;
-        gnbsim --cfg /tmp/gnbsim.yaml > /proc/1/fd/1 2> /proc/1/fd/2;
-        cp -f gnbsim.log ./gnbsim{{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}.log;
-        cp -f summary.log ./summary{{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}.log;
-        cp -f /tmp/gnbsim.yaml ./gnbsim{{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}.config;"
+    command: |
+      /bin/bash -o pipefail -c "
+      set -e
+      rm -rf *.log; rm -f *.config
+      gnbsim --cfg /tmp/gnbsim.yaml > /proc/1/fd/1 2> /proc/1/fd/2
+      run_suffix={{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}
+      cp -f gnbsim.log ./gnbsim${run_suffix}.log
+      cp -f summary.log ./summary${run_suffix}.log
+      cp -f /tmp/gnbsim.yaml ./gnbsim${run_suffix}.config
+      "
   async: 100
   poll: 0
   with_indexed_items: "{{ gnbsim.servers[lookup('ansible.utils.index_of', groups['gnbsim_nodes'], 'eq', inventory_hostname)] }}"

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -41,7 +41,9 @@
   community.docker.docker_container_exec:
     container: "{{ gnbsim.docker.container.prefix }}-{{ (item.0|int)+1 }}"
     command: /bin/bash -c "rm -rf *.log; rm -f *.config;
-        gnbsim --cfg /tmp/gnbsim.yaml 2&> gnbsim{{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}.log;
+        gnbsim --cfg /tmp/gnbsim.yaml > /proc/1/fd/1 2> /proc/1/fd/2;
+        cp -f gnbsim.log ./gnbsim{{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}.log;
+        cp -f summary.log ./summary{{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}.log;
         cp -f /tmp/gnbsim.yaml ./gnbsim{{ (item.0|int)+1 }}-{{ ansible_date_time.iso8601_basic_short }}.config;"
   async: 100
   poll: 0

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -37,6 +37,16 @@
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 
+- name: clear Docker logs for gnbsim containers
+  shell: |
+    log_path="{{ container_info.results[item.0].container.LogPath | default('') }}"
+    if [ -n "$log_path" ] && [ -f "$log_path" ]; then
+      truncate -s 0 "$log_path"
+    fi
+  with_indexed_items: "{{ gnbsim.servers[lookup('ansible.utils.index_of', groups['gnbsim_nodes'], 'eq', inventory_hostname)] }}"
+  when: inventory_hostname in groups['gnbsim_nodes']
+  become: true
+
 - name: start gnbsim
   community.docker.docker_container_exec:
     container: "{{ gnbsim.docker.container.prefix }}-{{ (item.0|int)+1 }}"


### PR DESCRIPTION
`gnbsim` logger already supports printing logs to both terminal and file (see `OutputPaths` below). This PR properly enables to print logs to terminal.

```go
	config := zap.Config{
		Level:            atomicLevel,
		Development:      false,
		Encoding:         "console",
		EncoderConfig:    zap.NewProductionEncoderConfig(),
		OutputPaths:      []string{"stdout", "gnbsim.log"},
		ErrorOutputPaths: []string{"stderr"},
	}

	...
	...
	...

	configSummary := zap.Config{
		Level:            atomicLevel,
		Development:      false,
		Encoding:         "console",
		EncoderConfig:    zap.NewProductionEncoderConfig(),
		OutputPaths:      []string{"stdout", "summary.log"},
		ErrorOutputPaths: []string{"stderr"},
	}

```

Before, when users run `docker logs gnbsim-1`, the output was empty
```
$ docker logs gnbsim-1
$
```

Here is an example with this PR when using `warn` level
```
$ docker logs gnbsim-1
2026-03-25T00:19:12.101Z        INFO    gnbsim/gnbsim.go:42     app name: GNBSIM        {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.103Z        INFO    gnbsim/gnbsim.go:81     setting log level to: warn      {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.103Z        INFO    logger/logger.go:114    set log level: warn     {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.103Z        INFO    logger/logger.go:52     set log level: warn     {"component": "LIB", "category": "NGAP"}
2026-03-25T00:19:12.103Z        INFO    logger/logger.go:56     set log level: warn     {"component": "LIB", "category": "NAS"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile2 [type: pdusessest]    {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile3 [type: anrelease]     {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile4 [type: uetriggservicereq]    {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile5 [type: deregister]    {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile6 [type: nwtriggeruedereg]     {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile7 [type: uereqpdusessrelease]  {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile8 [type: nwreqpdusessrelease]  {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile custom1 [type: custom] {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.364Z        ERROR   transport/cptransport.go:155    read EOF from client    {"component": "GNBSIM", "category": "GNodeB", "subcategory": "ControlPlaneTransport"}
```

```
$ docker exec gnbsim-1 cat gnbsim.log
2026-03-25T00:19:12.101Z        INFO    gnbsim/gnbsim.go:42     app name: GNBSIM        {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.103Z        INFO    gnbsim/gnbsim.go:81     setting log level to: warn      {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.103Z        INFO    logger/logger.go:114    set log level: warn     {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile2 [type: pdusessest]    {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile3 [type: anrelease]     {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile4 [type: uetriggservicereq]    {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile5 [type: deregister]    {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile6 [type: nwtriggeruedereg]     {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile7 [type: uereqpdusessrelease]  {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile profile8 [type: nwreqpdusessrelease]  {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.135Z        WARN    gnbsim/gnbsim.go:131    disabled profile custom1 [type: custom] {"component": "GNBSIM", "category": "App"}
2026-03-25T00:19:12.364Z        ERROR   transport/cptransport.go:155    read EOF from client    {"component": "GNBSIM", "category": "GNodeB", "subcategory": "ControlPlaneTransport"}
```